### PR TITLE
Enhance CMakeLists.txt to Support CUDA Detection in Non-Default Paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.17)
 include(CheckLanguage)
 
 project(peakperf CXX)
@@ -16,6 +16,7 @@ if(NOT DEFINED ENABLE_CPU_DEVICE)
 endif()
 
 if(NOT DEFINED ENABLE_GPU_DEVICE OR ENABLE_GPU_DEVICE)
+  find_package(CUDAToolkit REQUIRED)
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)


### PR DESCRIPTION
This PR augments the CMakeLists.txt to enable detection of CUDA libraries and compiler in locations other than their default installation paths. This is especially beneficial for setups where CUDA is installed via third-party package managers, such as [Spack](https://github.com/spack/spack).

By providing better flexibility in locating CUDA installations, this update ensures seamless integration for users who prefer or rely on alternative installation methods.