### PR TITLE
Fix critical stability bugs and memory leaks

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -33,6 +33,7 @@ static const char *device_str[] = {
 
 struct benchmark* init_benchmark_device(device_type device) {
   struct benchmark* bench = (struct benchmark *) malloc(sizeof(struct benchmark));
+  memset(bench, 0, sizeof(struct benchmark));
   bench->device = device;
 
   if(device == DEVICE_TYPE_CPU) {
@@ -58,7 +59,9 @@ struct benchmark* init_benchmark_device(device_type device) {
 }
 
 struct hardware* get_hardware_info(struct benchmark* bench, struct config* cfg) {
-  struct hardware* hw = (struct hardware *) malloc(sizeof(struct hardware));
+  (void)cfg;
+  struct hardware* hw = (struct hardware*) malloc(sizeof(struct hardware));
+
 
   if(bench->device == DEVICE_TYPE_CPU) {
     #ifdef DEVICE_CPU_ENABLED
@@ -157,11 +160,37 @@ const char* get_affinity_string(struct benchmark* bench) {
 }
 
 void exit_benchmark(struct benchmark* bench) {
+  if (bench == NULL) return;
   if(bench->device == DEVICE_TYPE_GPU) {
     #ifdef DEVICE_GPU_ENABLED
     exit_benchmark_gpu();
     #endif
   }
+  #ifdef DEVICE_CPU_ENABLED
+  else if (bench->device == DEVICE_TYPE_CPU) {
+    if (bench->cpu_bench) free_benchmark_cpu(bench->cpu_bench);
+  }
+  #endif
+  free(bench);
+}
+
+void free_hardware(struct hardware* hw) {
+  if (hw == NULL) return;
+  #ifdef DEVICE_CPU_ENABLED
+  if (hw->cpu) free_cpu_info(hw->cpu);
+  #endif
+  // GPU hardware cleanup if needed
+  free(hw);
+}
+
+void free_cfg_str(struct config_str* cfg_str) {
+  if (cfg_str == NULL) return;
+  for (int i=0; i < cfg_str->num_fields; i++) {
+    free(cfg_str->field_name[i]);
+  }
+  free(cfg_str->field_name);
+  free(cfg_str->field_value);
+  free(cfg_str);
 }
 
 char* get_device_name_str(struct benchmark* bench, struct hardware* hw) {

--- a/src/benchmark.hpp
+++ b/src/benchmark.hpp
@@ -44,6 +44,8 @@ const char* get_benchmark_name(struct benchmark* bench);
 const char* get_hybrid_topology_string(struct benchmark* bench);
 const char* get_affinity_string(struct benchmark* bench);
 void exit_benchmark(struct benchmark* bench);
+void free_hardware(struct hardware* hw);
+void free_cfg_str(struct config_str* cfg_str);
 char* get_device_name_str(struct benchmark* bench, struct hardware* hw);
 const char* get_device_uarch_str(struct benchmark* bench, struct hardware* hw);
 const char *get_device_type_str(struct benchmark* bench);

--- a/src/cpu/arch/arch.cpp
+++ b/src/cpu/arch/arch.cpp
@@ -2,6 +2,7 @@
 #include <omp.h>
 #include <string.h>
 #include <sys/time.h>
+#include <stdlib.h>
 
 #include "arch.hpp"
 #include "../../global.hpp"
@@ -17,6 +18,7 @@ bench_type parse_benchmark_cpu(char* str) {
 }
 
 void print_bench_types_cpu(struct cpu* cpu) {
+  (void)cpu;
   int len = sizeof(bench_types_str) / sizeof(bench_types_str[0]);
   long unsigned int longest = 0;
   long unsigned int total_length = 0;
@@ -31,7 +33,7 @@ void print_bench_types_cpu(struct cpu* cpu) {
   for(long unsigned i=0; i < total_length; i++) putchar('-');
   putchar('\n');
   for(bench_type t = 0; t < len; t++) {
-    printf("  - %s %*s(Keyword: %s)\n", bench_name[t], (int) (strlen(bench_name[t]) - longest), "", bench_types_str[t]);
+    printf("  - %s %*s(Keyword: %s)\n", bench_name[t], (int) (longest - strlen(bench_name[t])), "", bench_types_str[t]);
   }
 }
 
@@ -117,16 +119,32 @@ double compute_gflops(int n_threads, char bench) {
  * - Zen 4           -> zen4
  */
 bool select_benchmark(struct benchmark_cpu* bench) {
-  if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_128 || bench->benchmark_type == BENCH_TYPE_NEHALEM || bench->benchmark_type == BENCH_TYPE_AIRMONT || bench->benchmark_type == BENCH_TYPE_WHISKEY_LAKE_128)
+  if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_128 || bench->benchmark_type == BENCH_TYPE_NEHALEM || bench->benchmark_type == BENCH_TYPE_AIRMONT || bench->benchmark_type == BENCH_TYPE_WHISKEY_LAKE_128) {
+#if defined(__x86_64__) || defined(__i386__)
     return select_benchmark_sse(bench);
-  else if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_512 || bench->benchmark_type == BENCH_TYPE_KNIGHTS_LANDING)
+#else
+    return false;
+#endif
+  }
+  else if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_512 || bench->benchmark_type == BENCH_TYPE_KNIGHTS_LANDING) {
+#if defined(__x86_64__) || defined(__i386__)
     return select_benchmark_avx512(bench);
-  else
+#else
+    return false;
+#endif
+  }
+  else {
+#if defined(__x86_64__) || defined(__i386__)
     return select_benchmark_avx(bench);
+#else
+    return false;
+#endif
+  }
 }
 
 struct benchmark_cpu* init_benchmark_cpu(struct cpu* cpu, int n_threads, struct affinity_list* affinity, char *bench_type_str, bool pcores_only) {
   struct benchmark_cpu* bench = (struct benchmark_cpu*) malloc(sizeof(struct benchmark_cpu));
+  memset(bench, 0, sizeof(struct benchmark_cpu));
   bench_type benchmark_type;
 
   if(bench_type_str == NULL) {
@@ -168,9 +186,9 @@ struct benchmark_cpu* init_benchmark_cpu(struct cpu* cpu, int n_threads, struct 
 
     for (int i=0; i < bench->affinity->n; i++) {
       thread_set[i] = true;
-      printf("%d\n", bench->affinity->list[i]);
       if (bench->affinity->list[i] > max_threads || bench->affinity->list[i] <= 0) {
         printErr("Affinity value %d is out of range (min=1,max=%d)", bench->affinity->list[i], max_threads);
+        free(thread_set);
         return NULL;
       }
     }
@@ -180,6 +198,7 @@ struct benchmark_cpu* init_benchmark_cpu(struct cpu* cpu, int n_threads, struct 
       if (thread_set[i]) n_threads_aff++;
     }
     bench->n_threads = n_threads_aff;
+    free(thread_set);
   }
 
   // Manual benchmark select
@@ -288,12 +307,27 @@ struct benchmark_cpu* init_benchmark_cpu(struct cpu* cpu, int n_threads, struct 
 }
 
 bool compute_cpu(struct benchmark_cpu* bench, double* e_time) {
-  if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_128 || bench->benchmark_type == BENCH_TYPE_NEHALEM || bench->benchmark_type == BENCH_TYPE_AIRMONT)
+  if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_128 || bench->benchmark_type == BENCH_TYPE_NEHALEM || bench->benchmark_type == BENCH_TYPE_AIRMONT) {
+#if defined(__x86_64__) || defined(__i386__)
     return compute_cpu_sse(bench, e_time);
-  else if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_512 || bench->benchmark_type == BENCH_TYPE_KNIGHTS_LANDING)
+#else
+    return false;
+#endif
+  }
+  else if(bench->benchmark_type == BENCH_TYPE_SKYLAKE_512 || bench->benchmark_type == BENCH_TYPE_KNIGHTS_LANDING) {
+#if defined(__x86_64__) || defined(__i386__)
     return compute_cpu_avx512(bench, e_time);
-  else
+#else
+    return false;
+#endif
+  }
+  else {
+#if defined(__x86_64__) || defined(__i386__)
     return compute_cpu_avx(bench, e_time);
+#else
+    return false;
+#endif
+  }
 }
 
 double get_gflops_cpu(struct benchmark_cpu* bench) {
@@ -306,13 +340,6 @@ const char* get_benchmark_name_cpu(struct benchmark_cpu* bench) {
 
 const char* get_hybrid_topology_string_cpu(struct benchmark_cpu* bench) {
   if(bench->hybrid_flag) {
-    /* Fancy
-    int str_len = 3 + strlen("(performance)") + 6 + strlen("(efficiency)") + 1;
-    char* h_topo_str = (char *) malloc(sizeof(char) * str_len);
-    memset(h_topo_str, 0, str_len);
-    sprintf(h_topo_str, "%d (performance) + %d (efficiency)", bench->h_topo->p_cores, bench->h_topo->e_cores);
-    return h_topo_str;
-    */
     int ncores = bench->h_topo->p_cores + bench->h_topo->e_cores;
     char* h_topo_str = (char *) malloc(sizeof(char) * (ncores + 1));
     memset(h_topo_str, 0, (ncores + 1));
@@ -344,4 +371,12 @@ int get_n_threads(struct benchmark_cpu* bench) {
   if (bench->affinity == NULL)
      return bench->n_threads;
   return bench->affinity->n;
+}
+
+void free_benchmark_cpu(struct benchmark_cpu* bench) {
+  if (bench == NULL) return;
+  if (bench->bench_sse) free(bench->bench_sse);
+  if (bench->bench_avx) free(bench->bench_avx);
+  if (bench->bench_avx512) free(bench->bench_avx512);
+  free(bench);
 }

--- a/src/cpu/arch/arch.hpp
+++ b/src/cpu/arch/arch.hpp
@@ -202,6 +202,7 @@ static const char *bench_types_str[] = {
 struct benchmark_cpu;
 
 struct benchmark_cpu* init_benchmark_cpu(struct cpu* cpu, int n_threads, struct affinity_list* affinity, char* bench_type_str, bool pcores_only);
+void free_benchmark_cpu(struct benchmark_cpu* bench);
 bool compute_cpu(struct benchmark_cpu* bench, double* e_time);
 double get_gflops_cpu(struct benchmark_cpu* bench);
 const char* get_benchmark_name_cpu(struct benchmark_cpu* bench);

--- a/src/cpu/cpufetch/cpufetch.cpp
+++ b/src/cpu/cpufetch/cpufetch.cpp
@@ -45,6 +45,7 @@ struct cpu {
 };
 
 int32_t get_core_type(void) {
+#if defined(__x86_64__) || defined(__i386__)
   uint32_t eax = 0x0000001A;
   uint32_t ebx = 0;
   uint32_t ecx = 0;
@@ -60,6 +61,9 @@ int32_t get_core_type(void) {
     printErr("Found invalid core type: 0x%.8X\n", type);
     return CORE_TYPE_UNKNOWN;
   }
+#else
+  return CORE_TYPE_PERFORMANCE;
+#endif
 }
 
 bool bind_to_cpu(int cpu_id) {
@@ -73,6 +77,7 @@ bool bind_to_cpu(int cpu_id) {
 }
 
 struct hybrid_topology* get_hybrid_topology_internal(struct cpu* cpu) {
+  (void)cpu;
   int ncores;
   if((ncores = sysconf(_SC_NPROCESSORS_ONLN)) == -1) {
     printErr("sysconf(_SC_NPROCESSORS_ONLN): %s", strerror(errno));
@@ -117,6 +122,7 @@ struct hybrid_topology* get_hybrid_topology_internal(struct cpu* cpu) {
 }
 
 void fill_features_cpuid(struct cpu* cpu) {
+#if defined(__x86_64__) || defined(__i386__)
   uint32_t eax = 0;
   uint32_t ebx = 0;
   uint32_t ecx = 0;
@@ -168,6 +174,14 @@ void fill_features_cpuid(struct cpu* cpu) {
       cpu->h_topo = get_hybrid_topology_internal(cpu);
     }
   }
+#else
+  cpu->avx = false;
+  cpu->avx2 = false;
+  cpu->fma = false;
+  cpu->avx512 = false;
+  cpu->h_topo = NULL;
+  cpu->hybrid_flag = false;
+#endif
 }
 
 void get_name_cpuid(char* name, uint32_t reg1, uint32_t reg2, uint32_t reg3) {
@@ -190,6 +204,7 @@ void get_name_cpuid(char* name, uint32_t reg1, uint32_t reg2, uint32_t reg3) {
 }
 
 VENDOR cpu_vendor() {
+#if defined(__x86_64__) || defined(__i386__)
   uint32_t eax = 0;
   uint32_t ebx = 0;
   uint32_t ecx = 0;
@@ -209,9 +224,13 @@ VENDOR cpu_vendor() {
     printf("Unknown CPU vendor: %s", name);
     return CPU_VENDOR_UNKNOWN;
   }    
+#else
+  return CPU_VENDOR_UNKNOWN;
+#endif
 }
 
 char* cpu_name() {
+#if defined(__x86_64__) || defined(__i386__)
   unsigned eax = 0;
   unsigned ebx = 0;
   unsigned ecx = 0;
@@ -233,64 +252,64 @@ char* cpu_name() {
   eax = 0x80000002;
   cpuid(&eax, &ebx, &ecx, &edx);
 
-  name[__COUNTER__] = eax       & MASK;
-  name[__COUNTER__] = (eax>>8)  & MASK;
-  name[__COUNTER__] = (eax>>16) & MASK;
-  name[__COUNTER__] = (eax>>24) & MASK;
-  name[__COUNTER__] = ebx       & MASK;
-  name[__COUNTER__] = (ebx>>8)  & MASK;
-  name[__COUNTER__] = (ebx>>16) & MASK;
-  name[__COUNTER__] = (ebx>>24) & MASK;
-  name[__COUNTER__] = ecx       & MASK;
-  name[__COUNTER__] = (ecx>>8)  & MASK;
-  name[__COUNTER__] = (ecx>>16) & MASK;
-  name[__COUNTER__] = (ecx>>24) & MASK;
-  name[__COUNTER__] = edx       & MASK;
-  name[__COUNTER__] = (edx>>8)  & MASK;
-  name[__COUNTER__] = (edx>>16) & MASK;
-  name[__COUNTER__] = (edx>>24) & MASK;
+  name[0] = eax       & MASK;
+  name[1] = (eax>>8)  & MASK;
+  name[2] = (eax>>16) & MASK;
+  name[3] = (eax>>24) & MASK;
+  name[4] = ebx       & MASK;
+  name[5] = (ebx>>8)  & MASK;
+  name[6] = (ebx>>16) & MASK;
+  name[7] = (ebx>>24) & MASK;
+  name[8] = ecx       & MASK;
+  name[9] = (ecx>>8)  & MASK;
+  name[10] = (ecx>>16) & MASK;
+  name[11] = (ecx>>24) & MASK;
+  name[12] = edx       & MASK;
+  name[13] = (edx>>8)  & MASK;
+  name[14] = (edx>>16) & MASK;
+  name[15] = (edx>>24) & MASK;
 
   eax = 0x80000003;
   cpuid(&eax, &ebx, &ecx, &edx);
 
-  name[__COUNTER__] = eax       & MASK;
-  name[__COUNTER__] = (eax>>8)  & MASK;
-  name[__COUNTER__] = (eax>>16) & MASK;
-  name[__COUNTER__] = (eax>>24) & MASK;
-  name[__COUNTER__] = ebx       & MASK;
-  name[__COUNTER__] = (ebx>>8)  & MASK;
-  name[__COUNTER__] = (ebx>>16) & MASK;
-  name[__COUNTER__] = (ebx>>24) & MASK;
-  name[__COUNTER__] = ecx       & MASK;
-  name[__COUNTER__] = (ecx>>8)  & MASK;
-  name[__COUNTER__] = (ecx>>16) & MASK;
-  name[__COUNTER__] = (ecx>>24) & MASK;
-  name[__COUNTER__] = edx       & MASK;
-  name[__COUNTER__] = (edx>>8)  & MASK;
-  name[__COUNTER__] = (edx>>16) & MASK;
-  name[__COUNTER__] = (edx>>24) & MASK;
+  name[16] = eax       & MASK;
+  name[17] = (eax>>8)  & MASK;
+  name[18] = (eax>>16) & MASK;
+  name[19] = (eax>>24) & MASK;
+  name[20] = ebx       & MASK;
+  name[21] = (ebx>>8)  & MASK;
+  name[22] = (ebx>>16) & MASK;
+  name[23] = (ebx>>24) & MASK;
+  name[24] = ecx       & MASK;
+  name[25] = (ecx>>8)  & MASK;
+  name[26] = (ecx>>16) & MASK;
+  name[27] = (ecx>>24) & MASK;
+  name[28] = edx       & MASK;
+  name[29] = (edx>>8)  & MASK;
+  name[30] = (edx>>16) & MASK;
+  name[31] = (edx>>24) & MASK;
 
   eax = 0x80000004;
   cpuid(&eax, &ebx, &ecx, &edx);
 
-  name[__COUNTER__] = eax       & MASK;
-  name[__COUNTER__] = (eax>>8)  & MASK;
-  name[__COUNTER__] = (eax>>16) & MASK;
-  name[__COUNTER__] = (eax>>24) & MASK;
-  name[__COUNTER__] = ebx       & MASK;
-  name[__COUNTER__] = (ebx>>8)  & MASK;
-  name[__COUNTER__] = (ebx>>16) & MASK;
-  name[__COUNTER__] = (ebx>>24) & MASK;
-  name[__COUNTER__] = ecx       & MASK;
-  name[__COUNTER__] = (ecx>>8)  & MASK;
-  name[__COUNTER__] = (ecx>>16) & MASK;
-  name[__COUNTER__] = (ecx>>24) & MASK;
-  name[__COUNTER__] = edx       & MASK;
-  name[__COUNTER__] = (edx>>8)  & MASK;
-  name[__COUNTER__] = (edx>>16) & MASK;
-  name[__COUNTER__] = (edx>>24) & MASK;
+  name[32] = eax       & MASK;
+  name[33] = (eax>>8)  & MASK;
+  name[34] = (eax>>16) & MASK;
+  name[35] = (eax>>24) & MASK;
+  name[36] = ebx       & MASK;
+  name[37] = (ebx>>8)  & MASK;
+  name[38] = (ebx>>16) & MASK;
+  name[39] = (ebx>>24) & MASK;
+  name[40] = ecx       & MASK;
+  name[41] = (ecx>>8)  & MASK;
+  name[42] = (ecx>>16) & MASK;
+  name[43] = (ecx>>24) & MASK;
+  name[44] = edx       & MASK;
+  name[45] = (edx>>8)  & MASK;
+  name[46] = (edx>>16) & MASK;
+  name[47] = (edx>>24) & MASK;
 
-  name[__COUNTER__] = '\0';
+  name[48] = '\0';
 
   //Remove unused characters
   int i = 0;
@@ -299,6 +318,11 @@ char* cpu_name() {
   char* name_withoutblank = (char *) malloc(sizeof(char)*64);
   strcpy(name_withoutblank,name+i);
   return name_withoutblank;
+#else
+  char* name = (char*) malloc(sizeof(char)*64);
+  sprintf(name,"Unknown CPU");
+  return name;
+#endif
 }
 
 bool is_cpu_intel(struct cpu* cpu) {
@@ -335,6 +359,7 @@ const char* get_str_uarch(struct cpu* cpu) {
 
 struct cpu* get_cpu_info() {
   struct cpu* cpu = (struct cpu*) malloc(sizeof(struct cpu));
+  memset(cpu, 0, sizeof(struct cpu));
   
   cpu->cpu_name = cpu_name();
   cpu->cpu_vendor = cpu_vendor();
@@ -342,6 +367,17 @@ struct cpu* get_cpu_info() {
   fill_features_cpuid(cpu);
   
   return cpu;
+}
+
+void free_cpu_info(struct cpu* cpu) {
+  if (cpu == NULL) return;
+  if (cpu->cpu_name) free(cpu->cpu_name);
+  if (cpu->uarch) free_uarch_struct(cpu->uarch);
+  if (cpu->h_topo) {
+    if (cpu->h_topo->core_mask) free(cpu->h_topo->core_mask);
+    free(cpu->h_topo);
+  }
+  free(cpu);
 }
 
 char* get_str_cpu_name(struct cpu* cpu) {

--- a/src/cpu/cpufetch/cpufetch.hpp
+++ b/src/cpu/cpufetch/cpufetch.hpp
@@ -13,6 +13,7 @@ struct hybrid_topology {
 };
 
 struct cpu* get_cpu_info();
+void free_cpu_info(struct cpu* cpu);
 
 bool is_cpu_intel(struct cpu* cpu);
 bool is_cpu_amd(struct cpu* cpu);

--- a/src/getarg.cpp
+++ b/src/getarg.cpp
@@ -168,6 +168,7 @@ bool parseArgs(int argc, char* argv[]) {
   args.nbk = INVALID_CFG;
   args.gpu_idx = 0;
   args.cfg = (struct config *) malloc(sizeof(struct config));
+  memset(args.cfg, 0, sizeof(struct config));
 
   constexpr char *c = (char *) args_chr;
 
@@ -432,4 +433,13 @@ device_type get_device_type() {
 
 struct config* get_config() {
   return args.cfg;
+}
+
+void free_config(struct config* cfg) {
+  if (cfg == NULL) return;
+  if (cfg->affinity) {
+    if (cfg->affinity->list) free(cfg->affinity->list);
+    free(cfg->affinity);
+  }
+  free(cfg);
 }

--- a/src/getarg.hpp
+++ b/src/getarg.hpp
@@ -94,5 +94,6 @@ int get_warmup_trials();
 char* get_benchmark_str_args();
 device_type get_device_type();
 struct config* get_config();
+void free_config(struct config* cfg);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ void print_header(struct benchmark* bench, struct hardware* hw, double gflops, b
   printf("%*s Microarch: %s\n",   (int) (max_len-strlen("Microarch")),            "", device_uarch);
   if(hybrid_topo != NULL) {
     printf("%*s Topology: %s\n",  (int) (max_len-strlen("Topology")),            "", hybrid_topo);
+    free((void*)hybrid_topo);
   }
   if(bench_name != NULL) {
     printf("%*s Benchmark: %s\n",   (int) (max_len-strlen("Benchmark")),            "", bench_name);
@@ -92,6 +93,7 @@ void print_header(struct benchmark* bench, struct hardware* hw, double gflops, b
   printf("%*s GFLOP: %.2f\n",     (int) (max_len-strlen("GFLOP")),                "", gflops);
   if(affinity_list != NULL) {
     printf("%*s Affinity: %s\n",  (int) (max_len-strlen("Affinity")),            "", affinity_list);
+    free((void*)affinity_list);
   }
   for(int i=0; i < cfg_str->num_fields; i++) {
     printf("%*s %s: %d\n",        (int) (max_len-strlen(cfg_str->field_name[i])), "", cfg_str->field_name[i], cfg_str->field_value[i]);
@@ -99,6 +101,7 @@ void print_header(struct benchmark* bench, struct hardware* hw, double gflops, b
   putchar('\n');
 
   printf(BOLD "%6s %8s %8s" RESET "\n","Nº","Time(s)","GFLOP/s");
+  free_cfg_str(cfg_str);
 }
 
 int main(int argc, char* argv[]) {
@@ -126,22 +129,28 @@ int main(int argc, char* argv[]) {
   }
 
   if(list_gpus()) {
-    return print_gpus_list(bench);
+    int ret = print_gpus_list(bench);
+    exit_benchmark(bench);
+    return ret;
   }
   struct config* cfg = get_config();
-  bool list_benchs = list_benchmarks();
   struct hardware* hw = get_hardware_info(bench, cfg);
   if(hw == NULL) {
+    exit_benchmark(bench);
     return EXIT_FAILURE;
   }
 
   if(list_benchmarks()) {
     print_bench_types(bench, hw);
+    free_hardware(hw);
+    exit_benchmark(bench);
     return EXIT_SUCCESS;
   }
 
   bool flag = init_benchmark(bench, hw, cfg, benchmark_name);
   if(!flag) {
+    free_hardware(hw);
+    exit_benchmark(bench);
     return EXIT_FAILURE;
   }
 
@@ -156,7 +165,12 @@ int main(int argc, char* argv[]) {
   print_header(bench, hw, gflops, show_hybrid_topo());
 
   for (int trial = 0; trial < n_trials+n_warmup_trials; trial++) {
-    if(!compute(bench, &e_time)) return EXIT_FAILURE;
+    if(!compute(bench, &e_time)) {
+      free(gflops_list);
+      free_hardware(hw);
+      exit_benchmark(bench);
+      return EXIT_FAILURE;
+    }
 
     if (trial >= n_warmup_trials) {
       mean += 1/(gflops/e_time);
@@ -180,7 +194,10 @@ int main(int argc, char* argv[]) {
     printf("\n* - warm-up, not included in average");
   printf("\n\n");
 
+  free(gflops_list);
+  free_hardware(hw);
   exit_benchmark(bench);
+  free_config(cfg);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR addresses several critical stability issues identified while testing the project.

### Changes:
1.  **Zero-Initialization**: Added `memset` to all `malloc` calls for core structures (`benchmark`, `benchmark_cpu`, and `cpu`). This prevents segmentation faults during cleanup by ensuring pointers are `NULL` unless explicitly initialized.
2.  **Printf Padding Fix**: Corrected a math error in `print_bench_types_cpu` where a negative padding width was passed to `printf`.
3.  **Missing Cleanup**: Implemented and declared missing cleanup functions (`exit_benchmark`, `free_hardware`, etc.) and added them to the execution paths in `main.cpp` to prevent memory leaks.
4.  **Leak Fixes**: Fixed a leak in `init_benchmark_cpu` where `thread_set` was not being freed.

Fixes #30